### PR TITLE
Fix: 0.25x and 0.5x zoom selectors weren't converted to 8bpp

### DIFF
--- a/graphics/generate_graphics.py
+++ b/graphics/generate_graphics.py
@@ -141,7 +141,7 @@ for scale in scale_range([1, 4]):
 
 # selectors
 for scale in scale_range([0.25, 0.5, 1, 2, 4]):
-    custom_dither_directory(os.path.join(base_path, "selectors", str(scale * 64)))
+    custom_dither_directory(os.path.join(base_path, "selectors", str(int(scale * 64))))
 
 # vehicles
 for scale in scale_range([1, 4]):


### PR DESCRIPTION
Due to str(0.25 * 64) and str(0.5 * 64) being "16.0" and "32.0", rather than "16" and "32", so the directory was not found for 32bpp to 8bpp conversion.

A tiny mistake, but stops builds from clean as not all graphics files are available.