### PR TITLE
Zoom out optimisations

### DIFF
--- a/graphics/terrain/64/arctic_groundtiles_snowtransition_32bpp.pdn
+++ b/graphics/terrain/64/arctic_groundtiles_snowtransition_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ec73eee5b47ae5a0bf373d0407c1d8ca1c9762148bf75ef891170866a8f38bf
-size 966679
+oid sha256:ab22ca1212b308566f3560f605fcdd033a0926a5f39ce8ac443d394202da8d7b
+size 950822

--- a/graphics/terrain/64/arctic_groundtiles_snowtransition_32bpp.png
+++ b/graphics/terrain/64/arctic_groundtiles_snowtransition_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a36e8c27c855fe010e0040cc23d5dc3cbbf0af002b5df2dd231344806c13d810
-size 148918
+oid sha256:729f68e69a17e486b843c524bcb15a1c7f80e90362c8df288592437680a84f48
+size 162267

--- a/graphics/terrain/64/blends/snow_gtdev_finalblend3_32bpp.pdn
+++ b/graphics/terrain/64/blends/snow_gtdev_finalblend3_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5afef763698cc4a1214e8f70863dead48b11a35777d6ae1130d445345eade208
-size 82866
+oid sha256:4517f69a85891ed698f8f5a1e4b92024accb07ff0dc9c0ef689aee3b0c1da466
+size 89639

--- a/graphics/terrain/64/blends/zoom_pixelsused.pdn
+++ b/graphics/terrain/64/blends/zoom_pixelsused.pdn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02c04367c2e138c053c1ec7a343253f92d338afd0dc495e41715c7ff21391198
+size 4569

--- a/graphics/terrain/64/blends/zoom_testtiles.pdn
+++ b/graphics/terrain/64/blends/zoom_testtiles.pdn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:726cd70a5012a31693af300683f458757286cdd335a2dac33379ea74f82ab7a8
+size 5076

--- a/graphics/terrain/64/temperate_groundtiles_snowtransition_32bpp.pdn
+++ b/graphics/terrain/64/temperate_groundtiles_snowtransition_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ba900796bd26c96da21354b402e490964bb3304d25bb05b9d6bc30dfd252f72
-size 716768
+oid sha256:1a96ccde03a8905dc5071da3787f7d4823b221e548ab3eb382881fb22df7400f
+size 719894

--- a/graphics/terrain/64/temperate_groundtiles_snowtransition_32bpp.png
+++ b/graphics/terrain/64/temperate_groundtiles_snowtransition_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca22af39c08f1ce8a1db57296404103f9d0d1cdfb18ea51477136dd583e6a07c
-size 160811
+oid sha256:3d369ab14d61a0efdbae9e94ab2d9d8023738685ab335bb9bdf699c341f89071
+size 161273

--- a/graphics/terrain/64/toyland_watertile_32bpp.pdn
+++ b/graphics/terrain/64/toyland_watertile_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c7e09afadc52326454d00ee0c9ee446a434e583b32d6ad99fe16d8bb754e4d5
-size 6093
+oid sha256:4f7ef0aa2c0e3737aff9a770959229c97047feb7f3c40896b1e453d3a947beab
+size 6156

--- a/graphics/terrain/64/toyland_watertile_32bpp.png
+++ b/graphics/terrain/64/toyland_watertile_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:053995b5f3dfa1ce99a506d85c0db42fda95c0a5a3a42989e75d59d8b2a09757
-size 1232
+oid sha256:d9c49f1f038714ed9d3c812ab78825bf88de6025f15da9bc9b5a385a5fa45dfd
+size 1474

--- a/graphics/terrain/64/toyland_watertile_palmask.pdn
+++ b/graphics/terrain/64/toyland_watertile_palmask.pdn
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5102de74795e7b8f0a8c78031085a29f40b7b133918f4324498e962f5e226d03
+size 6157

--- a/graphics/terrain/64/toyland_watertile_palmask.png
+++ b/graphics/terrain/64/toyland_watertile_palmask.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:053995b5f3dfa1ce99a506d85c0db42fda95c0a5a3a42989e75d59d8b2a09757
-size 1232
+oid sha256:d9c49f1f038714ed9d3c812ab78825bf88de6025f15da9bc9b5a385a5fa45dfd
+size 1474

--- a/graphics/terrain/64/tropical_groundtiles_snowtransition_32bpp.pdn
+++ b/graphics/terrain/64/tropical_groundtiles_snowtransition_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c3c068c46596be0af0aeccedea08a2e866b627401ccaf96ab8d83df834d62a2
-size 724520
+oid sha256:ce8b4919d7eef47d0475947dcb4582b2bf96dd82cae84db25a9ad58fb36dc0f3
+size 712209

--- a/graphics/terrain/64/tropical_groundtiles_snowtransition_32bpp.png
+++ b/graphics/terrain/64/tropical_groundtiles_snowtransition_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62dc7d35fdd061d12a63de7b8778fa21081d2b95fdff09b01d5670a004e9cfeb
-size 149379
+oid sha256:b65f15119f75dd43115db655aab6fd4831924041db66e9b5d09a1df1566e3917
+size 163290

--- a/graphics/terrain/64/universal_watertile_32bpp.pdn
+++ b/graphics/terrain/64/universal_watertile_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a552d94c78980e4965ec46ccc62e3895a7acaa162906e1b2e477ce6590151559
-size 6151
+oid sha256:68190f1f8affba6ae2be19724c31ef237fcd4c2545f6927ae5d60277478ae500
+size 6242

--- a/graphics/terrain/64/universal_watertile_32bpp.png
+++ b/graphics/terrain/64/universal_watertile_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91d6138291ae8db2f96d03c5a70305bb8a6a45f879055baa7fbc97d9ed6a081f
-size 1207
+oid sha256:9252148defdbc10dbb64ea7691ed33d7e2892e8a0302fd843446cc1573de7586
+size 1447

--- a/graphics/terrain/64/universal_watertile_palmask.png
+++ b/graphics/terrain/64/universal_watertile_palmask.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91d6138291ae8db2f96d03c5a70305bb8a6a45f879055baa7fbc97d9ed6a081f
-size 1207
+oid sha256:a9980c526cc96e3351e9d3e40c0f92e4972fb4e38f3e6823e2971702f8377627
+size 1447

--- a/graphics/terrain/64/universalnocc_watertile_32bpp.pdn
+++ b/graphics/terrain/64/universalnocc_watertile_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d2367e2ce051a588a5c182ddf4d9bde06012a184bf50f01d616a2a0e08f299a
-size 7282
+oid sha256:dbfb106c05aaed618693411a5e1aa9e0b64febc113df0414cc04d33c79c54fc2
+size 7338

--- a/graphics/terrain/64/universalnocc_watertile_32bpp.png
+++ b/graphics/terrain/64/universalnocc_watertile_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0abcc8c93a46d6f80bf21968466ec144862897aabefe049dabdbc42c4449ba4
-size 1213
+oid sha256:427f2a6f0d595c199dcd77b054da6dabc4ec254607137d953169f936c060e32c
+size 1443

--- a/graphics/terrain/64/universalnocc_watertile_cbt32bpp.pdn
+++ b/graphics/terrain/64/universalnocc_watertile_cbt32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfff7d398d3b63061c02d21fabf99eee0ed5baa635f2d121dd45fa7a1a4c24d3
-size 6279
+oid sha256:369fd6e094fa3b2c7815fd30c6c5775bfbd35f2a66acc717f58c7fef26f92a7d
+size 6388

--- a/graphics/terrain/64/universalnocc_watertile_cbt32bpp.png
+++ b/graphics/terrain/64/universalnocc_watertile_cbt32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:171dbf87af70247bf66ec7bae3d61d37d0ba5efec0835f16b5053a81156b6fe9
-size 497
+oid sha256:51472c7e95b3540836136ad3db4f45789cd2953dae14b2a8fc41d7fedec892fa
+size 720

--- a/graphics/terrain/64/universalnocc_watertile_gridline_32bpp.pdn
+++ b/graphics/terrain/64/universalnocc_watertile_gridline_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99f7e29c9d83bacd991d477a3eb5e9f0b1a2529a0fdf6e5014d55725746018e4
-size 7514
+oid sha256:626f6dfe7ea4f86a10c7bfbcd2a345cca8f5e7ff4a23289458f1c44c3f4bdcd7
+size 7571

--- a/graphics/terrain/64/universalnocc_watertile_gridline_32bpp.png
+++ b/graphics/terrain/64/universalnocc_watertile_gridline_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf2f9672c5edcf6b23c21f1476e805829e1e4716b7cba2cb4fbc487f21f11cd1
-size 1189
+oid sha256:84546434399c6cdea823f2663b3727a5dc9103e5a200dc66885a7e5f15fc2225
+size 1420

--- a/graphics/terrain/64/universalnocc_watertile_gridline_cbt32bpp.pdn
+++ b/graphics/terrain/64/universalnocc_watertile_gridline_cbt32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3db2489a82581c5d7006e413df9d70cc8a572348a74edd8f38476e2ca49a4d4e
-size 6552
+oid sha256:6db1b611fd6fff4c7cf79a8e179fad6cc4d21b21701c7f012b7b967d4c4accdf
+size 6661

--- a/graphics/terrain/64/universalnocc_watertile_gridline_cbt32bpp.png
+++ b/graphics/terrain/64/universalnocc_watertile_gridline_cbt32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bd6f8d3255c8d861425ac881801a079b5f796ec4208f0bfd32c4ebf6fd6edde
-size 544
+oid sha256:bce27ce2928868af3118a5d924e4bd7f809891895be8106d74ea472c94d4d4d3
+size 772

--- a/graphics/terrain/64/universalnocc_watertile_gridline_palmask.pdn
+++ b/graphics/terrain/64/universalnocc_watertile_gridline_palmask.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9838f0c94e9ece5c2969560c5e4274a9e3f9482311a72803752a5d852e6fc09d
-size 7514
+oid sha256:7c63d5f4faaf8bb5000b540dcb7a384f24d28bd9d49bff235ed3a50af6a043be
+size 7575

--- a/graphics/terrain/64/universalnocc_watertile_gridline_palmask.png
+++ b/graphics/terrain/64/universalnocc_watertile_gridline_palmask.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf2f9672c5edcf6b23c21f1476e805829e1e4716b7cba2cb4fbc487f21f11cd1
-size 1189
+oid sha256:84546434399c6cdea823f2663b3727a5dc9103e5a200dc66885a7e5f15fc2225
+size 1420

--- a/graphics/terrain/64/universalnocc_watertile_palmask.pdn
+++ b/graphics/terrain/64/universalnocc_watertile_palmask.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2227252a25b5d9dc9bf20917864bac0e362edbee1924a7b6caae3868c8feccbf
-size 7282
+oid sha256:5e964e93673c2698cf8cce84f31d7780e4950c10fbe1f2ea3bf7f491957ffaf4
+size 7338

--- a/graphics/terrain/64/universalnocc_watertile_palmask.png
+++ b/graphics/terrain/64/universalnocc_watertile_palmask.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0abcc8c93a46d6f80bf21968466ec144862897aabefe049dabdbc42c4449ba4
-size 1213
+oid sha256:c5c954e80a880a5405c3de54f1295fab707a0abe8d38a3c8f43f9333b18c5d46
+size 1444


### PR DESCRIPTION
Hand optimisation of strategic pixels in water and terrain tiles to give a better result when zoomed out. Two changes:

![image](https://github.com/user-attachments/assets/81dae6a1-6e66-47ea-ae6b-ecaccf2a13ba)
1. Map the pixels used at 4x (yellow) and 8x (pink) zoom out, and use to ensure that animated water pixels are not visible. This removes the strobing or flickering effect when looking at zoomed out water.

![image](https://github.com/user-attachments/assets/3826f138-7cda-4105-9e84-103e973a4477)
![image](https://github.com/user-attachments/assets/1a98c35c-560e-46c0-af4c-dfb7dd4f73a9)
2. Hand-optimise pixels used at 4x and 8x zoom out for snow transitions to ensure that the flat tile matches the snow density with a decent dither pattern.

Both normal climate and toyland water updated, snow transitions for all three normal climates updated.
