### PR TITLE
Fix: Correct accidental re-definition of alternative sprites

### DIFF
--- a/baseset/nml/base/base-1440-houses.pnml
+++ b/baseset/nml/base/base-1440-houses.pnml
@@ -275,13 +275,13 @@ base_graphics spr1523(1523, "../graphics/towns/temperate/64/pygen/flats_8bpp.png
 base_graphics spr1524(1524, "../graphics/towns/temperate/64/pygen/flats_base_8bpp.png") { template_house_1x1(130, 150, 1, 74) }
 #32 alternative_sprites(spr1524, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/flats_base_bt32bpp.png") { template_house_1x1(130, 150, 1, 74) }
 base_graphics spr1525(1525, "../graphics/towns/temperate/64/pygen/flats_8bpp.png") { template_house_1x1(130, 150, 1, 74) }
-#ez alternative_sprites(spr1525, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/flats_bt32bpp.png") { template_house_1x1(130, 150, 4, 74) }
+#ez alternative_sprites(spr1525, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/towns/temperate/256/pygen/flats_8bpp.png") { template_house_1x1(130, 150, 4, 74) }
 #32 alternative_sprites(spr1525, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/flats_bt32bpp.png") { template_house_1x1(130, 150, 1, 74) }
 #32 #ez alternative_sprites(spr1525, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/flats_bt32bpp.png") { template_house_1x1(130, 150, 4, 74) }
 base_graphics spr1526(1526, "../graphics/towns/temperate/64/pygen/flats_base_8bpp.png") { template_house_1x1(130, 75, 1, 74) }
 #32 alternative_sprites(spr1526, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/flats_base_bt32bpp.png") { template_house_1x1(130, 75, 1, 74) }
 base_graphics spr1527(1527, "../graphics/towns/temperate/64/pygen/flats_8bpp.png") { template_house_1x1(130, 75, 1, 74) }
-#ez alternative_sprites(spr1527, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/flats_bt32bpp.png") { template_house_1x1(130, 75, 4, 74) }
+#ez alternative_sprites(spr1527, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/towns/temperate/256/pygen/flats_8bpp.png") { template_house_1x1(130, 75, 4, 74) }
 #32 alternative_sprites(spr1527, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/flats_bt32bpp.png") { template_house_1x1(130, 75, 1, 74) }
 #32 #ez alternative_sprites(spr1527, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/flats_bt32bpp.png") { template_house_1x1(130, 75, 4, 74) }
 base_graphics spr1528(1528, "../graphics/towns/temperate/64/pygen/flats_base_8bpp.png") { template_house_1x1(130, 0, 1, 74) }
@@ -333,8 +333,8 @@ base_graphics spr1543(1543, "../graphics/towns/temperate/64/pygen/shopsandoffice
 base_graphics spr1544(1544, "../graphics/towns/temperate/64/pygen/shopsandoffices_base_8bpp.png") { template_house_1x1(325,  0, 1, 95) }
 #32 alternative_sprites(spr1544, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/shopsandoffices_base_bt32bpp.png") { template_house_1x1(325,  0, 1, 95) }
 base_graphics spr1545(1545, "../graphics/towns/temperate/64/pygen/shopsandoffices_8bpp.png") { template_house_1x1(325,  0, 1, 95) }
+#ez alternative_sprites(spr1545, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/towns/temperate/256/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 4, 95) }
 #32 alternative_sprites(spr1545, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 1, 95) }
-#ez alternative_sprites(spr1545, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 4, 95) }
 #ez #32 alternative_sprites(spr1545, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 4, 95) }
 
 //1546-1551 office tower

--- a/baseset/nml/base/base-2692-roadstops-docks.pnml
+++ b/baseset/nml/base/base-2692-roadstops-docks.pnml
@@ -2,7 +2,7 @@
 //2692-2707 bus stop
 base_graphics spr2692(2692, "../graphics/infrastructure/64/pygen/road_general_concrete_8bpp.png") { template_roadstoptiles(0, 0, 1) } // ground tiles
 #ez alternative_sprites(spr2692, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/infrastructure/256/pygen/road_general_concrete_8bpp.png") { template_roadstoptiles(0, 0, 4) }
-//#32 alternative_sprites(spr2692, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/infrastructure/64/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 1) }
+#32 alternative_sprites(spr2692, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/infrastructure/64/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 1) }
 #32 #ez alternative_sprites(spr2692, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/infrastructure/256/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 4) }
 base_graphics spr2696(2696, "../graphics/stations/general/64/pygen/roadstops_8bpp.png") { template_busstop(325, 0, 1) } // building sprites
 #32 alternative_sprites(spr2696, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/stations/general/64/pygen/roadstops_rm32bpp.png", "../graphics/stations/general/64/pygen/roadstops_8bpp.png") { template_busstop(325, 0, 1) }
@@ -12,8 +12,8 @@ base_graphics spr2696(2696, "../graphics/stations/general/64/pygen/roadstops_8bp
 //2708-2723 lorry stop
 base_graphics spr2708(2708, "../graphics/infrastructure/64/pygen/road_general_concrete_8bpp.png") { template_roadstoptiles(0, 0, 1) } // ground tiles
 #ez alternative_sprites(spr2708, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/infrastructure/256/pygen/road_general_concrete_8bpp.png") { template_roadstoptiles(0, 0, 4) }
-#32 alternative_sprites(spr2692, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/infrastructure/64/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 1) }
-#32 #ez alternative_sprites(spr2692, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/infrastructure/256/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 4) }
+#32 alternative_sprites(spr2708, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/infrastructure/64/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 1) }
+#32 #ez alternative_sprites(spr2708, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/infrastructure/256/pygen/road_general_concrete_bt32bpp.png") { template_roadstoptiles(0, 0, 4) }
 base_graphics spr2712(2712, "../graphics/stations/general/64/pygen/roadstops_8bpp.png") { template_lorrystop(0, 0, 1) } // building sprites
 #32 alternative_sprites(spr2712, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/stations/general/64/pygen/roadstops_rm32bpp.png", "../graphics/stations/general/64/pygen/roadstops_8bpp.png") { template_lorrystop(0, 0, 1) }
 #ez alternative_sprites(spr2712, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/stations/general/256/pygen/roadstops_8bpp.png") { template_lorrystop(0, 0, 4) }

--- a/baseset/nml/base/base-4404-houses-town-snow.pnml
+++ b/baseset/nml/base/base-4404-houses-town-snow.pnml
@@ -15,7 +15,7 @@ base_graphics spr4411(4411, "../graphics/towns/temperate/64/pygen/2x2_mallandsta
 
 //4418-4427 double house
 base_graphics spr4418(4418, "../graphics/towns/arctic/64/pygen/largehouses_base_8bpp.png") { template_house_short(  0,  0, 1) }
-#32 alternative_sprites(spr4404, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_base_bt32bpp.png") {  template_house_short(  0,  0, 1) }
+#32 alternative_sprites(spr4418, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_base_bt32bpp.png") {  template_house_short(  0,  0, 1) }
 base_graphics spr4419(4419, "../graphics/towns/arctic/64/pygen/largehouses_snow_base_8bpp.png") { template_house_short(  0,  0, 1) }
 #32 alternative_sprites(spr4419, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_snow_base_bt32bpp.png") { template_house_short(  0,  0, 1) }
 template template_spr4420(z) {
@@ -26,14 +26,14 @@ template template_spr4420(z) {
 base_graphics spr4420(4420, "../graphics/towns/arctic/64/pygen/largehouses_8bpp.png") { template_spr4420(1) }
 #32 alternative_sprites(spr4420, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_bt32bpp.png") { template_spr4420(1) }
 base_graphics spr4423(4423, "../graphics/towns/arctic/64/pygen/largehouses_snow_8bpp.png") { template_house_short(  0,  0, 1) }
-#32 alternative_sprites(spr4420, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_snow_bt32bpp.png") { template_house_short(  0,  0, 1) }
+#32 alternative_sprites(spr4423, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_snow_bt32bpp.png") { template_house_short(  0,  0, 1) }
 template template_spr4424(z) {
 	template_house_short( 65, 96, z)
 	template_house_short( 65, 48, z)
 	template_house_short( 65,  0, z)
 }
 base_graphics spr4424(4424, "../graphics/towns/arctic/64/pygen/largehouses_8bpp.png") { template_spr4424(1) }
-#32 alternative_sprites(spr4420, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_bt32bpp.png") { template_spr4424(1) }
+#32 alternative_sprites(spr4424, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_bt32bpp.png") { template_spr4424(1) }
 base_graphics spr4427(4427, "../graphics/towns/arctic/64/pygen/largehouses_snow_8bpp.png") { template_house_short( 65,  0, 1) }
 #32 alternative_sprites(spr4427, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/largehouses_snow_bt32bpp.png") { template_house_short( 65,  0, 1) }
 
@@ -119,7 +119,7 @@ base_graphics spr4457(4457, "../graphics/towns/arctic/64/pygen/houses_snow_8bpp.
 base_graphics spr4458(4458, "../graphics/towns/arctic/64/pygen/shopsandoffices_base_8bpp.png") { template_house_1x1( 65,  0, 1, 95) }
 #32 alternative_sprites(spr4458, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/shopsandoffices_base_bt32bpp.png") { template_house_1x1( 65,  0, 1, 95) }
 base_graphics spr4459(4459, "../graphics/towns/arctic/64/pygen/shopsandoffices_combo_8bpp.png") { template_house_1x1( 65,192, 1, 95) }
-#32 alternative_sprites(spr4462, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/shopsandoffices_combo_bt32bpp.png") { template_house_1x1( 65,192, 1, 95) }
+#32 alternative_sprites(spr4459, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/shopsandoffices_combo_bt32bpp.png") { template_house_1x1( 65,192, 1, 95) }
 template template_spr4460(z) {
 	template_house_1x1( 65, 96, z, 95)
 	template_house_1x1( 65,  0, z, 95)
@@ -177,17 +177,17 @@ base_graphics spr4477(4477, "../graphics/towns/arctic/64/pygen/shopsandoffices_8
 
 //4480-4484 tall office block
 base_graphics spr4480(4480, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_8bpp.png") { template_house_1x1(195,124, 1, 123) }
-#32 alternative_sprites(spr4487, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_bt32bpp.png") { template_house_1x1(195,124, 1, 123) }
+#32 alternative_sprites(spr4480, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_bt32bpp.png") { template_house_1x1(195,124, 1, 123) }
 template template_spr4481(z) {
 	template_house_1x1(195,248, z, 123)
 	template_house_1x1(195,124, z, 123)
 }
 base_graphics spr4481(4481, "../graphics/towns/arctic/64/pygen/tallofficeblock_8bpp.png") { template_spr4481(1) }
-#32 alternative_sprites(spr4487, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_bt32bpp.png") { template_spr4481(1) }
+#32 alternative_sprites(spr4481, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_bt32bpp.png") { template_spr4481(1) }
 base_graphics spr4483(4483, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_8bpp.png") { template_house_1x1(195,  0, 1, 123) }
-#32 alternative_sprites(spr4487, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_bt32bpp.png") { template_house_1x1(195,  0, 1, 123) }
+#32 alternative_sprites(spr4483, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_base_bt32bpp.png") { template_house_1x1(195,  0, 1, 123) }
 base_graphics spr4484(4484, "../graphics/towns/arctic/64/pygen/tallofficeblock_8bpp.png") { template_house_1x1(195,  0, 1, 123) }
-#32 alternative_sprites(spr4487, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_bt32bpp.png") { template_house_1x1(195,  0, 1, 123) }
+#32 alternative_sprites(spr4484, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/tallofficeblock_bt32bpp.png") { template_house_1x1(195,  0, 1, 123) }
 
 //4485-4492 tall 1x2 office block
 template template_spr4485(z) {
@@ -195,7 +195,7 @@ template template_spr4485(z) {
 	template_house_1x1( 65,  0, z, 115)
 }
 base_graphics spr4485(4485, "../graphics/towns/arctic/64/pygen/1x2_tallofficeblock_base_tiles_8bpp.png") { template_spr4485(1) }
-#32 alternative_sprites(spr4487, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/1x2_tallofficeblock_base_tiles_bt32bpp.png") { template_spr4485(1) }
+#32 alternative_sprites(spr4485, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/arctic/64/pygen/1x2_tallofficeblock_base_tiles_bt32bpp.png") { template_spr4485(1) }
 template template_spr4487(z) {
 	template_house_1x1(  0,232, z, 115)
 	template_house_1x1( 65,232, z, 115)

--- a/baseset/nml/extra/extra-overlay-rocks.pnml
+++ b/baseset/nml/extra/extra-overlay-rocks.pnml
@@ -7,6 +7,6 @@ template template_overlay_rocks(z) {
     template_groundtiles(0, 192, z)
 }
 replacenew overlay_rocks(OVERLAY_ROCKS, "../graphics/terrain/64/general_rockoverlay_alt_snowtransition_8bpp.png", 0) { template_overlay_rocks(1) }
-#ez alternative_sprites(overlay_rocks, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/terrain/256/general_rockoverlay_alt_snowtransition_8bpp.png") { template_overlay_rocks(4) }
+#ez alternative_sprites(overlay_rocks, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/terrain/256/general_rockoverlay_alt_snowtransition_8bpp.png") { template_overlay_rocks(4) }
 #32 alternative_sprites(overlay_rocks, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/terrain/64/general_rockoverlay_alt_snowtransition_bt32bpp.png") { template_overlay_rocks(1) }
 #32 #ez alternative_sprites(overlay_rocks, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/terrain/256/general_rockoverlay_alt_snowtransition_bt32bpp.png") { template_overlay_rocks(4) }

--- a/baseset/nml/extra/extra-param-terrain.pnml
+++ b/baseset/nml/extra/extra-param-terrain.pnml
@@ -1470,8 +1470,8 @@ if (param_gridlines==2) {
         // 4061-4069 shore tiles
         replace watergrid_arctic_spr4062(4062, "../graphics/terrain/64/pygen/arctic_grass_gridline_shoretiles_gridline_8bpp.png") { template_watertiles_base(0, 0, 1) }
         #ez alternative_sprites(watergrid_arctic_spr4062, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/terrain/256/pygen/arctic_grass_gridline_shoretiles_gridline_8bpp.png") { template_watertiles_base(0, 0, 4) }
-        #32 alternative_sprites(watergrid_coast_tiles_arctic, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/terrain/64/pygen/arctic_grass_gridline_shoretiles_gridline_rm32bpp.png", "../graphics/terrain/64/pygen/arctic_grass_gridline_shoretiles_gridline_8bpp.png") { template_watertiles_full(0, 0, 1) }
-        #32 #ez alternative_sprites(watergrid_coast_tiles_arctic, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/terrain/256/pygen/arctic_grass_gridline_shoretiles_gridline_rm32bpp.png", "../graphics/terrain/256/pygen/arctic_grass_gridline_shoretiles_gridline_8bpp.png") { template_watertiles_full(0, 0, 4) }
+        #32 alternative_sprites(watergrid_arctic_spr4062, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/terrain/64/pygen/arctic_grass_gridline_shoretiles_gridline_rm32bpp.png", "../graphics/terrain/64/pygen/arctic_grass_gridline_shoretiles_gridline_8bpp.png") { template_watertiles_base(0, 0, 1) }
+        #32 #ez alternative_sprites(watergrid_arctic_spr4062, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/terrain/256/pygen/arctic_grass_gridline_shoretiles_gridline_rm32bpp.png", "../graphics/terrain/256/pygen/arctic_grass_gridline_shoretiles_gridline_8bpp.png") { template_watertiles_base(0, 0, 4) }
 
         // Extra coasts
         // COAST_TILES_BASEGFX

--- a/baseset/nml/toyland/toyland-0134-roads.pnml
+++ b/baseset/nml/toyland/toyland-0134-roads.pnml
@@ -4,7 +4,7 @@ base_graphics spr134(134, "../graphics/infrastructure/64/pygen/road_toyland_conc
 
 //153-171 roads
 base_graphics spr153(153, "../graphics/infrastructure/64/pygen/road_toyland_grass_8bpp.png") { template_roadtiles(0, 0, 1) }
-#32 alternative_sprites(spr134, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/infrastructure/64/pygen/road_toyland_grass_rm32bpp.png", "../graphics/infrastructure/64/pygen/road_toyland_grass_8bpp.png") { template_roadtiles(0, 0, 1) }
+#32 alternative_sprites(spr153, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/infrastructure/64/pygen/road_toyland_grass_rm32bpp.png", "../graphics/infrastructure/64/pygen/road_toyland_grass_8bpp.png") { template_roadtiles(0, 0, 1) }
 
 //172-173 streetlights
 base_graphics spr172(172, "../graphics/towns/streetfurniture/64/town_lamp_toyland_8bpp.png") { template_road_lights_tall(0, 0, 1) }


### PR DESCRIPTION
Fixes a set of `alternative_sprite` type/bit depth, zoom, or block name errors, which give hard-to-detect graphical errors under various combinations of blitter and maximum zoom level. Caught by encoding using nml without `--quiet` which which suppresses reporting these re-definitions as they are only warnings.