### PR TITLE
Fix: Cursors, caps lock and backspace on-screen keyboard icons

### DIFF
--- a/baseset/nml/extra/extra-openttd-gui.pnml
+++ b/baseset/nml/extra/extra-openttd-gui.pnml
@@ -262,17 +262,27 @@ replacenew ottd_gui137(OTTD_GUI, "../graphics/cursors/1/pygen/default_8bpp.png",
 	template_cursor_matrix(3, 13, 1) // cursor waterways: build rivers
 }
 
-// OTTD_GUI 148-143 small icons (unknown use?)
+// OTTD_GUI 138-143 onscreen keyboard icons
 template template_ottd_gui138(z) {
-	template_sprite_matrix_nocrop(8, 8, 0, 0, 1, 2, z) // (?) arrow left
-	template_sprite_matrix_nocrop(8, 8, 0, 0, 2, 2, z) // (?) arrow right
-	template_sprite_matrix_nocrop(8, 8, 0, 0, 3, 3, z) // (?) open arrow down
-	template_sprite_matrix_nocrop(8, 8, 0, 0, 2, 3, z) // (?) open arrow up
-	template_sprite_matrix_nocrop(8, 8, 0, 0, 0, 3, z) // (?) open arrow left
-	template_sprite_matrix_nocrop(8, 8, 0, 0, 4, 3, z) // (?) command symbol
+	template_sprite_matrix_nocrop(8, 8, 0, 0, 0, 2, z) // cursor left
+	template_sprite_matrix_nocrop(8, 8, 0, 0, 1, 2, z) // cursor right
+	template_sprite_matrix_nocrop(8, 8, 0, 0, 7, 3, z) // caps lock
+	template_sprite_matrix_nocrop(8, 8, 0, 0, 2, 3, z) // shift
 }
 replacenew ottd_gui138(OTTD_GUI, "../graphics/icons/1/icons_8px_8bpp.png", 138) { template_ottd_gui138(1) }
 alternative_sprites (ottd_gui138, ZOOM_LEVEL_IN_2X, BIT_DEPTH_8BPP, "../graphics/icons/2/icons_8px_8bpp.png") { template_ottd_gui138(2) }
+
+template template_ottd_gui142(z) {
+	template_sprite_matrix_nocrop(14, 8, 0, 0, 2, 0, z) // backspace
+}
+replacenew ottd_gui142(OTTD_GUI, "../graphics/icons/1/icons_textdelete_8bpp.png", 142) { template_ottd_gui142(1) }
+alternative_sprites (ottd_gui142, ZOOM_LEVEL_IN_2X, BIT_DEPTH_8BPP, "../graphics/icons/2/icons_textdelete_8bpp.png") { template_ottd_gui142(2) }
+
+template template_ottd_gui143(z) {
+	template_sprite_matrix_nocrop(8, 8, 0, 0, 4, 3, z) // meta/command
+}
+replacenew template_ottd_gui143(OTTD_GUI, "../graphics/icons/1/icons_8px_8bpp.png", 143) { template_ottd_gui143(1) }
+alternative_sprites (template_ottd_gui143, ZOOM_LEVEL_IN_2X, BIT_DEPTH_8BPP, "../graphics/icons/2/icons_8px_8bpp.png") { template_ottd_gui143(2) }
 
 // OTTD_GUI 144-145 more icons
 template template_ottd_gui144(z) {

--- a/graphics/icons/1/icons_14x10px_32bpp.png
+++ b/graphics/icons/1/icons_14x10px_32bpp.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04f5278d1c4ed3caa2a7b5f957f11d41b0b6e5fef683bcf8d3765ff8d6d40ee8
-size 209

--- a/graphics/icons/1/icons_8px_32bpp.pdn
+++ b/graphics/icons/1/icons_8px_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46f18aa80aa750ec05adcfbe243e89b3e2ac781612e93e74a10c4ed0fdc4fbed
-size 4791
+oid sha256:6f5ab98165c83d36dbb4889c9d2312ebdd78f7e8ad1f60729dc5a33edef4560b
+size 5039

--- a/graphics/icons/1/icons_8px_32bpp.png
+++ b/graphics/icons/1/icons_8px_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c64653f0aeebcde9800767851374305abc425d47b417774a2e9d2c8b36c6f990
-size 568
+oid sha256:3928f0b916523ba6fba6fe44898a89a0d4fd3ea1e88c7eeb27068cac82a2e8c4
+size 1293

--- a/graphics/icons/1/icons_textdelete_32bpp.pdn
+++ b/graphics/icons/1/icons_textdelete_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e63798ffd97f200f0b0d08a3164b81d0f42ddb05c0cd327a531bd8106d341b46
-size 3735
+oid sha256:d6f3c37dc746987ed25a9bd9ec339df2e8ce1aab3b81769d8a14f84ccbde6be4
+size 4058

--- a/graphics/icons/1/icons_textdelete_32bpp.png
+++ b/graphics/icons/1/icons_textdelete_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f29e9f3f562bbd96d4cdba69d398e62594ee36afc23aea40e04a7fb9e9f14be
-size 208
+oid sha256:d681496f37d8494e1d3cd47dc64a6e8a266ae2456df767fb76519ac8be8369ff
+size 600

--- a/graphics/icons/2/icons_14x10px_32bpp.pdn
+++ b/graphics/icons/2/icons_14x10px_32bpp.pdn
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f6c2bba682b05dd48cf71ea7abe13080b5023972615a5842270b4779063f9f4
-size 3926

--- a/graphics/icons/2/icons_14x10px_32bpp.png
+++ b/graphics/icons/2/icons_14x10px_32bpp.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3fa4a7d27680bd1c8914fe7e70734eb8f9ec92d4fd114e19a927ed8e1dbf2cc
-size 259

--- a/graphics/icons/2/icons_8px_32bpp.pdn
+++ b/graphics/icons/2/icons_8px_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbdda14ab8f4f4e54b86c46a76582c0927343d25318abab2b73319d2998eaef5
-size 6494
+oid sha256:b2e56448d0f4dec9c77a8826b3f1a9c08db677c3cbe0545f399be489a68c1091
+size 6708

--- a/graphics/icons/2/icons_8px_32bpp.png
+++ b/graphics/icons/2/icons_8px_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e9faa2e0e678480f155daa7893e2d447f44eb9fa45d041aa25c0e0a4527dc16
-size 1060
+oid sha256:c2606070371bef2354d4cf09933f867aa5113d716cc149a33ad52b1ca536d3bf
+size 2483

--- a/graphics/icons/2/icons_textdelete_32bpp.pdn
+++ b/graphics/icons/2/icons_textdelete_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6bc8ca5decb821a3679305986d10edad740d8dba8a97f8ad9ab7f2b929a85707
-size 3944
+oid sha256:42c2011aa2fd4981cb3b95026fed1211a8cf1b03150f772fc6beeec933b8cd1d
+size 4317

--- a/graphics/icons/2/icons_textdelete_32bpp.png
+++ b/graphics/icons/2/icons_textdelete_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:854e381d841298ca8c06dd8c4305a4f490fdaf4b0d5c3b33f448f0fb8b743d8f
-size 437
+oid sha256:97b8a6154276be6de89aeb36e1e1e34e3723cc2498c8d98deca033095f0e6e91
+size 854


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/17474a8f-408d-4b90-9da3-f022dcab6f54)

Sprites for the on-screen keyboard cursors were incorrect. This was because I hadn't worked out what they were for, and made a mistake coding them.

Now I know what they're for: 1) fix the cursor orientation and 2) add dedicated caps lock (broken hollow up arrow) and backspace (long left arrow) icons. 1x and 2x zoom sprites. This revealed an unused duplicate of the clear all text icon, so 3) remove those unused images.