### PR TITLE
Fix: Incorrect image for 4x zoom 8bpp sprite for spr1545

### DIFF
--- a/baseset/nml/base/base-1440-houses.pnml
+++ b/baseset/nml/base/base-1440-houses.pnml
@@ -333,7 +333,7 @@ base_graphics spr1543(1543, "../graphics/towns/temperate/64/pygen/shopsandoffice
 base_graphics spr1544(1544, "../graphics/towns/temperate/64/pygen/shopsandoffices_base_8bpp.png") { template_house_1x1(325,  0, 1, 95) }
 #32 alternative_sprites(spr1544, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/shopsandoffices_base_bt32bpp.png") { template_house_1x1(325,  0, 1, 95) }
 base_graphics spr1545(1545, "../graphics/towns/temperate/64/pygen/shopsandoffices_8bpp.png") { template_house_1x1(325,  0, 1, 95) }
-#ez alternative_sprites(spr1545, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/towns/temperate/256/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 4, 95) }
+#ez alternative_sprites(spr1545, ZOOM_LEVEL_IN_4X, BIT_DEPTH_8BPP, "../graphics/towns/temperate/256/pygen/shopsandoffices_8bpp.png") { template_house_1x1(325,  0, 4, 95) }
 #32 alternative_sprites(spr1545, ZOOM_LEVEL_NORMAL, BIT_DEPTH_32BPP, "../graphics/towns/temperate/64/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 1, 95) }
 #ez #32 alternative_sprites(spr1545, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP, "../graphics/towns/temperate/256/pygen/shopsandoffices_bt32bpp.png") { template_house_1x1(325,  0, 4, 95) }
 


### PR DESCRIPTION
Fix sprite 1545 8bpp 4x zoom variant pointing to a 32bpp+alpha image instead of an 8bpp one.

Introduced in cfeb9a8. It'd be nice to blame testing problems fixed through 7dd3f5f, but realistically I must have forgotten to test the High Def build. (CI would be nice!).