### PR TITLE
Fix: Correct check for change in number of graphics source files

### DIFF
--- a/graphics/generate_graphics.py
+++ b/graphics/generate_graphics.py
@@ -32,7 +32,7 @@ if os.path.exists(touchfile_path):
     if old_file_count == "":
         old_file_count = 0
     else:
-        old_file_count = int()
+        old_file_count = int(old_file_count)
     # check if any files modified or file number changed since last run
     if os.path.getmtime(latest_file) < os.path.getmtime(touchfile_path) and os.path.getmtime(__file__) < os.path.getmtime(touchfile_path) and file_count == old_file_count:
         print("Skipping all processing, output up-to-date")


### PR DESCRIPTION
`generate_graphics.py` does a pre-scan of the graphics directory, looking for number of files and when they were changed, and comparing this to the temp file recording the previous run (`graphics_X.tmp`). It should run the full graphics generation if the most recent modification is more recent than the temp file, if the script has been modified more recently than the temp file, or if the number of files has changed.

Because of a silly mistake (forgetting to pass an argument to `int()`), it always compared the number of files to zero (`int()=0`), so always did a full graphics generation run. This PR fixes that.