### PR TITLE
Fix: Correct path capitalisation for OpenTTD-TTF

### DIFF
--- a/makefile
+++ b/makefile
@@ -113,7 +113,7 @@ graphics_%.tmp: graphics/fonts/openttd-ttf FORCE
 
 # Get font git dependencies
 graphics/fonts/openttd-ttf:
-	cd graphics/fonts && git clone https://github.com/OpenTTD/OpenTTD-TTF
+	cd graphics/fonts && git clone https://github.com/OpenTTD/OpenTTD-TTF openttd-ttf
 
 # Clean
 .PHONY: clean


### PR DESCRIPTION
The OpenTTD-TTF repo is cloned to get the latest version of the TTF font for sprite font generation during graphics generation.

Changing the OpenTTD-TTF repo to the OpenTTD organisation changed it from an all lowercase `openttd-ttf` to capitalised `OpenTTD-TTF` repo name. The repo was cloned without a target directory, which meant the cloned repo could not be found in case-sensitive file systems.

Clone to lowercase `openttd-ttf` directory to ensure it can be found in case-sensitive file systems. Fixes #180

However, worth a discussion about the best way to fetch the TTF font files. Nice to grab the repo to fetch the latest updates, but better to download from the latest release and fetch versions in a more controlled way?