### PR TITLE
Fix: Correct track orientation for monorail level crossing

### DIFF
--- a/graphics/infrastructure/256/monorail_levelcrossing_overlayalpha.pdn
+++ b/graphics/infrastructure/256/monorail_levelcrossing_overlayalpha.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:630a3e90b7d55d852128ac3bb3e9aa0224113f7a72a1391038c7eb6b3a02dbf3
-size 25083
+oid sha256:f58aa95b11d5c03a0240b6a1a6a4ccce7d0d7f3d7fb32c13825ceef1eeb0e1fd
+size 23282

--- a/graphics/infrastructure/256/monorail_levelcrossing_overlayalpha.png
+++ b/graphics/infrastructure/256/monorail_levelcrossing_overlayalpha.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5d8ae02f37ee93f72631e17cc02013204bfc2a0d5919ee35654b12d5ea0f753
-size 7297
+oid sha256:b9ff9adc02521e24f3fc31ebe14eedec532c47e801c32b3816c682bb21192086
+size 9276


### PR DESCRIPTION
Only affected 4x zoom active monorail in the SW-NE direction. Road and lights were correct, only monorail track orientation was incorrect. Fixes #179