### PR TITLE
Fix: Missing tall office block ground tiles

### DIFF
--- a/graphics/towns/temperate/64/tallofficeblock_base_shape.pdn
+++ b/graphics/towns/temperate/64/tallofficeblock_base_shape.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62c0aa3046a8f289d87be209fc0fad9228af77d5314d599404c933d7016696e3
-size 19916
+oid sha256:09702de5fdaebf5b2d1bf2c2732ac8d4552807e0b41b02628be0c6889f3e0861
+size 21646

--- a/graphics/towns/temperate/64/tallofficeblock_base_shape.png
+++ b/graphics/towns/temperate/64/tallofficeblock_base_shape.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1854c7a6bf16c37b3b1478d98a8477fd9f446a1393f8e5503899894fc25ce96d
-size 2792
+oid sha256:d871acb3eaedcbd040eb6c56735b86435b09919c6ea5cb359cfd185483a996c2
+size 2642


### PR DESCRIPTION
Construction stage ground tiles were blank transparent sprites. Add muddy then concrete (without fence) ground tiles for construction stages. Actual added image is a 'shape' image, which is processed to generate the textured sprites.

![image](https://github.com/user-attachments/assets/5fa6358d-1e22-4551-a7de-39fed843ac55)
