### PR TITLE
Fix: Add missing baseset obg file url metadata

### DIFF
--- a/baseset/baseset_generate_obg.py
+++ b/baseset/baseset_generate_obg.py
@@ -213,6 +213,7 @@ def generate_obg(base_path, type_string):
     obg.write(pad("version", pad_length, pad_left=False) + "= 7" + "\n")
     obg.write(pad("palette", pad_length, pad_left=False) + "= DOS" + "\n")
     obg.write(pad("blitter", pad_length, pad_left=False) + "= "+str(blitter)+"bpp" + "\n")
+    obg.write(pad("url", pad_length, pad_left=False) + "= https://github.com/OpenTTD/OpenGFX2/" + "\n")
     # write all non-default languages with translations available
     if descriptionstrid is not None:
       for lng in lngs:


### PR DESCRIPTION
Baseset `obg` files can take an (undocumented) `url` metadata value. When set, enables the website link in game options.

Update `baseset_generate_obg.py` to include the OpenGFX2 Github repo as `url` metadata.

![image](https://github.com/user-attachments/assets/305a186b-4efd-45e3-b8e5-f9885fed598e)
