### PR TITLE
Fix: Protect special magenta shades in building shape processing

### DIFF
--- a/graphics/towns/shapeproc.py
+++ b/graphics/towns/shapeproc.py
@@ -80,7 +80,7 @@ def buildings_shapeproc(scale, climate, snow, base_path, verbose=True):
 
   # Special palette details
   # Values to exclude during dithering
-  palette_exclude = [0,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,245,246,247,248,249,250,251,252,253,254,254,255]
+  palette_exclude = [0,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,245,246,247,248,249,250,251,252,253,254,254,255]
   palette_generalmask = [0, 255]
 
 


### PR DESCRIPTION
Add magenta shades (palette indices 216-226) to protected special palette entries (previously just blue, white and animated) for building shape processing.

Outset blurs during building shape texturing/colouring process could previously overflow onto the magenta shades, changing their colour. Pure magenta needs to be 'protected' from modification, as it is used to mark grassy areas for tunnel overlay onto terrain tiles. Just index 226, which is pure magenta, could be protected, but instead opted to add all magenta shades as they shouldn't normally be used.

![image](https://github.com/user-attachments/assets/0fc72c60-2d92-4ed9-8683-f40084b9a775)

Fixes #191
Road tunnel sprites could look nicer... but that's a separate problem.