### PR TITLE
Feature: Add left-pointing arrow to sprite font

### DIFF
--- a/graphics/fonts/charactergrab.py
+++ b/graphics/fonts/charactergrab.py
@@ -139,6 +139,8 @@ def fonts_charactergrab(base_path):
         {"start": 8470, "end": 8471}, # Letter-like symbols
         {"start": 8482, "end": 8482}, # Letter-like symbols
         {"start": 10216, "end": 10217}, # Mathematical symbols
+        # Extended private use range
+        {"start": 58013, "end": 58013},
       ]
     },
   ]


### PR DESCRIPTION
The sprite font is generated from the OpenTTD-TTF fonts. Update to grab the new private range character for the left-pointing arrow: Add `U+E29D` (`58013`) to range of characters grabbed for a bitmap imprint. Fixes #194