### PR TITLE
Feature: Add vertical ellipsis used for badges menu

### DIFF
--- a/baseset/nml/extra/extra-openttd-gui.pnml
+++ b/baseset/nml/extra/extra-openttd-gui.pnml
@@ -418,3 +418,10 @@ template template_ottd_gui186(z) {
 }
 replacenew ottd_gui186(OTTD_GUI, "../graphics/icons/1/icons_network_8bpp.png", 186) { template_ottd_gui186(1) }
 alternative_sprites (ottd_gui186, ZOOM_LEVEL_IN_2X, BIT_DEPTH_8BPP, "../graphics/icons/2/icons_network_8bpp.png") { template_ottd_gui186(2) }
+
+// OTTD_GUI 191 menu vertical ellipsis
+template template_ottd_gui191(z) {
+	template_sprite_matrix_nocrop(8, 8, 0, 0, 6, 2, z) // menu vertical ellipsis
+}
+replacenew ottd_gui191(OTTD_GUI, "../graphics/icons/1/icons_8px_8bpp.png", 191) { template_ottd_gui191(1) }
+alternative_sprites (ottd_gui191, ZOOM_LEVEL_IN_2X, BIT_DEPTH_8BPP, "../graphics/icons/2/icons_8px_8bpp.png") { template_ottd_gui191(2) }

--- a/graphics/icons/1/icons_8px_32bpp.pdn
+++ b/graphics/icons/1/icons_8px_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f5ab98165c83d36dbb4889c9d2312ebdd78f7e8ad1f60729dc5a33edef4560b
-size 5039
+oid sha256:3318b847f6484a74c778de9d38ef03c44cc372d4e5b5e0d322567879000fba50
+size 5034

--- a/graphics/icons/1/icons_8px_32bpp.png
+++ b/graphics/icons/1/icons_8px_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3928f0b916523ba6fba6fe44898a89a0d4fd3ea1e88c7eeb27068cac82a2e8c4
-size 1293
+oid sha256:de7adb1c87af2d0dd5054db5ff2601d319659f13f1880c7e03a53ce4d975bc80
+size 801

--- a/graphics/icons/2/icons_8px_32bpp.pdn
+++ b/graphics/icons/2/icons_8px_32bpp.pdn
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2e56448d0f4dec9c77a8826b3f1a9c08db677c3cbe0545f399be489a68c1091
-size 6708
+oid sha256:24713a2e0da2354ef581b0182ef5b2bf937e29881b2080fdb58c737fd79df4b2
+size 6723

--- a/graphics/icons/2/icons_8px_32bpp.png
+++ b/graphics/icons/2/icons_8px_32bpp.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2606070371bef2354d4cf09933f867aa5113d716cc149a33ad52b1ca536d3bf
-size 2483
+oid sha256:77a419978d91befaf7b21890ec1fa51db07c858e650aadc76acf049d3286e4ce
+size 1324


### PR DESCRIPTION
A new icon was added to `OTTD_GUI` in the extra NewGRF for the badges menu.

![image](https://github.com/user-attachments/assets/523eb80d-555e-4e4b-a832-b0560739dd15)

Added 1x and 2x zoom icons.