### PR TITLE
Fix: mapping for Maori is missing

### DIFF
--- a/baseset/baseset_generate_obg.py
+++ b/baseset/baseset_generate_obg.py
@@ -102,7 +102,7 @@ def generate_obg(base_path, type_string):
     "0x3d": "en_AU",
     "0x3e": "tr_TR",
     #0x3f
-    #0x40
+    "0x40": "mi_NZ",
     #0x41
     "0x42": "th_TH",
     #0x43


### PR DESCRIPTION
Since 9fb2716ca2d4f503c05dfa04bf5e355764868d5c the build fails because that commit adds a Maori translation without the mapping.

I haven't tested this; I hope the CI will be able to check whether this works.